### PR TITLE
fix undeclared var w, assigned to line 576

### DIFF
--- a/src/BigInt.js
+++ b/src/BigInt.js
@@ -473,7 +473,7 @@
     //generate a k-bit true random prime using Maurer's algorithm,
     //and put it into ans.  The bigInt ans must be large enough to hold it.
     function randTruePrime_(ans,k) {
-      var c,m,pm,dd,j,r,B,divisible,z,zz,recSize;
+      var c,m,pm,dd,j,r,B,divisible,w,z,zz,recSize;
 
       if (primes.length==0)
         primes=findPrimes(30000);  //check for divisibility by primes <=30000


### PR DESCRIPTION
Big Integer Library v. 5.5 is failing with an attempt to write to an undeclared variable w at line 576. For example:

> BigInt.bigInt2str(BigInt.randTruePrime(100),10)
> ReferenceError: assignment to undeclared variable w

This error was not flagged in earlier versions because they did not invoke strict mode.

Fixed by adding a declaration at line 476.